### PR TITLE
Add TWZRD Agent Intel MCP server (Solana x402 trust scoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A list of awesome AI projects built in Ruby! 🤖❤️
 - [mcp](https://github.com/modelcontextprotocol/ruby-sdk) - The official Ruby SDK for Model Context Protocol servers and clients
 - [rails-mcp-server](https://github.com/maquina-app/rails-mcp-server)
 - [tidewave_rails](https://github.com/tidewave-ai/tidewave_rails)
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring for AI agent wallets on Solana. Verify agent identity before x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ### Books
 


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the MCP section.

TWZRD Agent Intel is a free MCP server for trust scoring AI agent wallets on Solana. It lets Ruby apps and AI agents verify agent identity before processing x402 micropayments.

**Tools:**
- `score_agent(wallet)` — returns trust score (0–100), risk flags, activity history
- `preflight_check(wallet)` — validates wallet before a payment or action
- `get_trust_receipt(wallet)` — paid tool (x402 micropayment) that returns a signed receipt

**Config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Relevant for Ruby developers building agentic apps, Rails-based AI services, or anything using MCP + x402 micropayments on Solana.